### PR TITLE
Adds #sneaky_save!

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ gem 'sneaky-save', git: 'git://github.com/einzige/sneaky-save.git'
 
 ## Using
 ```ruby
-# Update
-@existed_record.sneaky_save
+# Update. Returns true on success, false otherwise.
+existing_record.sneaky_save
 
-# Insert
+# Insert. Returns true on success, false otherwise.
 Model.new.sneaky_save
+
+# Raise exception on failure.
+record.sneaky_save!
 ```
 
 ## Running specs

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -13,13 +13,24 @@ module SneakySave
   # @return [false, true]
   def sneaky_save
     begin
-      new_record? ? sneaky_create : sneaky_update
+      sneaky_create_or_update
     rescue ActiveRecord::StatementInvalid
       false
     end
   end
 
+  # Saves the record raising an exception if it fails.
+  # @return [true] if save was successful.
+  # @raise [ActiveRecord::StatementInvalid] if save failed.
+  def sneaky_save!
+    sneaky_create_or_update
+  end
+
   protected
+
+    def sneaky_create_or_update
+      new_record? ? sneaky_create : sneaky_update
+    end
 
     # Makes INSERT query in database without running any callbacks
     # @return [false, true]

--- a/spec/lib/sneaky_save_spec.rb
+++ b/spec/lib/sneaky_save_spec.rb
@@ -1,67 +1,87 @@
 require 'spec_helper'
 
 describe SneakySave, use_connection: true do
-  after :each do 
-    expect(subject.sneaky_save).to eq(true)
-  end
-
   context 'new record' do
-    subject { Fake.new }
+    subject { Fake.new(name: 'test') }
 
-    it('returns true if everything is good') {}
+    describe '#sneaky_save' do
+      it 'returns true if everything is good' do
+        expect(subject.sneaky_save).to eq(true)
+      end
 
-    it 'does insert of the new record' do
-      allow(subject).to receive(:sneaky_create).once.and_return(true)
+      it 'inserts the new record' do
+        allow(subject).to receive(:sneaky_create).once.and_return(true)
+        expect(subject.sneaky_save).to eq(true)
+      end
+
+      it 'stores attributes in database' do
+        subject.name = 'test'
+        expect(subject.sneaky_save).to eq(true)
+        subject.reload
+        expect(subject.name).to eq('test')
+      end
+
+      it 'does not call any callback' do
+        Fake.any_instance.should_not_receive :before_save_callback
+        subject.sneaky_save
+      end
+
+      it 'does not call validations' do
+        expect_any_instance_of(Fake).to_not receive(:valid?)
+        subject.sneaky_save
+      end
     end
 
-    it 'stores attributes in database' do
-      subject.name = 'test'
-      subject.sneaky_save
-      subject.reload
-      expect(subject.name).to eq('test')
-    end
-
-    it 'does not call any callback' do
-      Fake.any_instance.should_not_receive :before_save_callback
-    end
-
-    it 'does not call validations' do
-      Fake.any_instance.should_not_receive :valid?
+    describe '#sneaky_save!' do
+      it 'raises an exception when insert fails' do
+        subject.name = nil
+        expect { subject.sneaky_save! }.to raise_error(ActiveRecord::StatementInvalid)
+      end
     end
   end
 
   context 'existing record' do
-    subject { Fake.create :name => 'test' }
+    subject { Fake.create! :name => 'test' }
 
-    context 'record is not changed' do
-      it 'does nothing' do
-        Fake.should_not_receive(:update_all)
+    describe '#sneaky_save' do
+      context 'record is not changed' do
+        it 'does nothing' do
+          Fake.should_not_receive(:update_all)
+          expect(subject.sneaky_save).to eq(true)
+        end
+      end
+
+      context 'record is changed' do
+        it 'updates attributes' do
+          subject.should_receive(:sneaky_update).once.and_return true
+          subject.name = 'new name'
+          expect(subject.sneaky_save).to eq(true)
+        end
+
+        it 'stores attributes in database' do
+          subject.name = 'new name'
+          expect(subject.sneaky_save).to eq(true)
+          subject.reload
+          expect(subject.name).to eq('new name')
+          expect(subject.sneaky_save).to eq(true)
+        end
+
+        it 'does not call any callback' do
+          subject.should_not_receive :before_save_callback
+          subject.sneaky_save
+        end
+
+        it 'does not call validations' do
+          subject.should_not_receive :valid?
+          subject.sneaky_save
+        end
       end
     end
 
-    context 'record is changed' do
-      after :each do
-        subject.name = 'new name'
-      end
-
-      it 'updates attributes' do
-        subject.should be_valid
-        subject.should_receive(:sneaky_update).once.and_return true
-      end
-
-      it 'stores attributes in database' do
-        subject.name = 'new name'
-        expect(subject.sneaky_save).to eq(true)
-        subject.reload
-        expect(subject.name).to eq('new name')
-      end
-
-      it 'does not call any callback' do
-        subject.should_not_receive :before_save_callback
-      end
-
-      it 'does not call validations' do
-        subject.should_not_receive :valid?
+    describe '#sneaky_save!' do
+      it 'raises an exception when update fails' do
+        subject.name = nil
+        expect { subject.sneaky_save! }.to raise_error(ActiveRecord::StatementInvalid)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,12 +7,12 @@ shared_context 'use connection', use_connection: true do
 
   ActiveRecord::Schema.define do
     create_table 'fakes' do |table|
-      table.column :name, :string
+      table.column :name, :string, null: false
     end
   end
 
   class Fake < ActiveRecord::Base
-    validates_presence_of :name
+    validates :name, presence: true
 
     before_save :before_save_callback
 


### PR DESCRIPTION
- This is similar to `ActiveRecord::Base#save!`. Our use-cases always need a whiny `sneaky_save!` (similar to when you would prefer to use `save!`) as we never expect it to fail. When it does, we want it to complain loudly with the inner exception. Instead of repeating that pattern in our code-base, we've pushed it into this gem.
- The specs had to be re-org'ed a bit to accommodate its testing.

@einzige Let me know what you think.
