### PR TITLE
Fix Rails 3 serialized attributes

### DIFF
--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -68,8 +68,18 @@ module SneakySave
     pk = self.class.primary_key
     original_id = changed_attributes.key?(pk) ? changes[pk].first : send(pk)
 
+    changed_attributes = sneaky_update_fields
+
+    # Serialize values for rails3 before updating
+    unless sneaky_new_rails?
+      serialized_fields = self.class.serialized_attributes.keys & changed_attributes.keys
+      serialized_fields.each do |field|
+        changed_attributes[field] = @attributes[field].serialized_value
+      end
+    end
+
     !self.class.where(pk => original_id).
-      update_all(sneaky_update_fields).zero?
+      update_all(changed_attributes).zero?
   end
 
   def sneaky_attributes_values

--- a/spec/lib/sneaky_save_spec.rb
+++ b/spec/lib/sneaky_save_spec.rb
@@ -30,6 +30,13 @@ describe SneakySave, use_connection: true do
         expect_any_instance_of(Fake).to_not receive(:valid?)
         subject.sneaky_save
       end
+
+      it "updates serialized column" do
+        expect do
+           fake.config = {one: :two}
+           fake.sneaky_save!
+        end.to change { fake.reload.config }.from(nil).to(one: :two)
+      end
     end
 
     describe "#sneaky_save!" do
@@ -71,10 +78,11 @@ describe SneakySave, use_connection: true do
 
         it "stores attributes in database" do
           subject.name = "new name"
+          subject.config = {test: "test"}
           expect(subject.sneaky_save).to eq(true)
           subject.reload
           expect(subject.name).to eq("new name")
-          expect(subject.sneaky_save).to eq(true)
+          expect(subject.config).to eq({test: "test"})
         end
 
         it "does not call any callback" do

--- a/spec/lib/sneaky_save_spec.rb
+++ b/spec/lib/sneaky_save_spec.rb
@@ -32,10 +32,10 @@ describe SneakySave, use_connection: true do
       end
 
       it "updates serialized column" do
-        expect do
-          subject.config = { one: :two }
-          subject.sneaky_save!
-        end.to change { subject.reload.config }.from(nil).to(one: :two)
+        subject.config = { test: "test" }
+        expect(subject.sneaky_save).to eq(true)
+        subject.reload
+        expect(subject.config).to eq(test: "test")
       end
     end
 

--- a/spec/lib/sneaky_save_spec.rb
+++ b/spec/lib/sneaky_save_spec.rb
@@ -33,8 +33,8 @@ describe SneakySave, use_connection: true do
 
       it "updates serialized column" do
         expect do
-           subject.config = {one: :two}
-           subject.sneaky_save!
+          subject.config = { one: :two }
+          subject.sneaky_save!
         end.to change { subject.reload.config }.from(nil).to(one: :two)
       end
     end
@@ -82,7 +82,7 @@ describe SneakySave, use_connection: true do
           expect(subject.sneaky_save).to eq(true)
           subject.reload
           expect(subject.name).to eq("new name")
-          expect(subject.config).to eq({test: "test"})
+          expect(subject.config).to eq(test: "test")
         end
 
         it "does not call any callback" do

--- a/spec/lib/sneaky_save_spec.rb
+++ b/spec/lib/sneaky_save_spec.rb
@@ -33,9 +33,9 @@ describe SneakySave, use_connection: true do
 
       it "updates serialized column" do
         expect do
-           fake.config = {one: :two}
-           fake.sneaky_save!
-        end.to change { fake.reload.config }.from(nil).to(one: :two)
+           subject.config = {one: :two}
+           subject.sneaky_save!
+        end.to change { subject.reload.config }.from(nil).to(one: :two)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ shared_context "use connection", use_connection: true do
     before_save :before_save_callback
 
     belongs_to :belonger
-    
+
     serialize :config, Hash
 
     def before_save_callback

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ shared_context "use connection", use_connection: true do
     create_table "fakes" do |table|
       table.column :name, :string, null: false
       table.column :belonger_id, :integer
+      table.column :config, :text
     end
 
     create_table "belongers" do |table|
@@ -25,6 +26,8 @@ shared_context "use connection", use_connection: true do
     before_save :before_save_callback
 
     belongs_to :belonger
+    
+    serialize :config, Hash
 
     def before_save_callback
       "BEFORE SAVE CALLED"


### PR DESCRIPTION
- [x] Add spec

@ritikesh 

Going forward, let's have our updates separated in commits.

For a spec, you'll need to update `spec/spe_helper.rb` where you'll find a test class called "Fake", just add a new column to it and serialize the way you did in your app. 

It may also require you to add conditional spec / code depending on a currently running rails/AR version, eg: `if ActiveRecord.version < 4 then add serialization, run this spec`
