### PR TITLE
Update sneaky_create to update internal rails 5 structure correctly

### DIFF
--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -40,8 +40,9 @@ module SneakySave
                                    .except { |key| key.name == "id" }
 
     column_keys = sneaky_attributes_without_id.keys
-                  .map { |key| "\"#{key}\"" } # to avoid conflicts with column names
+                  .map { |key| "\"#{key.name}\"" } # to avoid conflicts with column names
                   .join(", ")
+
     dynamic_keys = sneaky_attributes_without_id.keys
                    .map { |key| ":#{key.name}" }
                    .join(", ")

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -129,7 +129,7 @@ module SneakySave
     attributes_for_create = send :attributes_for_create, attribute_names
     attributes_with_values = send :attributes_with_values, attributes_for_create
     attributes_with_values.each_with_object({}) do |attribute_value, hash|
-      hash[self.class.send(:arel_attribute, attribute_value[0])] = attribute_value[1]
+      hash[self.class.arel_table[attribute_value[0]]] = attribute_value[1]
     end
   end
 

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -4,6 +4,10 @@
 #++
 module SneakySave
 
+  class NonEnumerableRange < Range
+    undef :map
+  end
+
   # Saves the record without running callbacks/validations.
   # Returns true if the record is changed.
   # @note - Does not reload updated record by default.
@@ -138,7 +142,10 @@ module SneakySave
     # by manipulating ranges so that they are not seen as iterable and will be properly handled by
     # ActiveRecord::Sanitization.quote_bound_value
     # https://github.com/rails/rails/issues/36682
-    value.instance_eval('undef :map') if value.is_a?(Range)
+    if value.is_a?(Range)
+      # Ranges are frozen in Ruby 3. We construct a new Range that isn't enumerable.
+      return NonEnumerableRange.new(value.first, value.end)
+    end
     value
   end
 

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -63,6 +63,10 @@ module SneakySave
     mapping = generate_insert_mapping(sneaky_attributes_without_id)
     data = self.class.unscoped.find_by_sql([sql.squish, mapping.to_h]).first
 
+    # To trigger generation of @mutations_from_database variable
+    # which is necessary for id_in_database
+    data.send(:mutations_from_database)
+
     copy_internal(data, "@attributes")
     copy_internal(data, "@mutations_from_database")
     copy_internal(data, "@changed_attributes")

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -11,9 +11,9 @@ module SneakySave
   #       - Saves only belongs_to relations.
   #
   # @return [false, true]
-  def sneaky_save
+  def sneaky_save(avoid_insert_conflict: nil)
     begin
-      sneaky_create_or_update
+      sneaky_create_or_update(avoid_insert_conflict: avoid_insert_conflict)
     rescue ActiveRecord::StatementInvalid
       false
     end
@@ -23,19 +23,19 @@ module SneakySave
   # @see ActiveRecord::Base#sneaky_save
   # @return [true] if save was successful.
   # @raise [ActiveRecord::StatementInvalid] if saving failed.
-  def sneaky_save!
-    sneaky_create_or_update
+  def sneaky_save!(avoid_insert_conflict: nil)
+    sneaky_create_or_update(avoid_insert_conflict: avoid_insert_conflict)
   end
 
   protected
 
-  def sneaky_create_or_update
-    new_record? ? sneaky_create : sneaky_update
+  def sneaky_create_or_update(avoid_insert_conflict: nil)
+    new_record? ? sneaky_create(avoid_insert_conflict: avoid_insert_conflict) : sneaky_update
   end
 
   # Performs INSERT query without running any callbacks
   # @return [false, true]
-  def sneaky_create
+  def sneaky_create(avoid_insert_conflict: nil)
     sneaky_attributes_without_id = sneaky_attributes_values
                                    .except { |key| key.name == "id" }
 
@@ -44,29 +44,19 @@ module SneakySave
                    .map { |key| ":#{key.name}" }
                    .join(", ")
 
-    mapping = sneaky_attributes_without_id.map do |definition, value|
-      if definition.able_to_type_cast?
-        result = definition.type_cast_for_database(value)
-        if result.is_a?(Struct)
-          if result.respond_to?(:encoder)
-            [definition.name.to_sym, result.encoder.encode(value)]
-          else
-            raise RuntimeError.new('Unknown Type Casted Struct')
-          end
-        else
-          [definition.name.to_sym, result]
-        end
-      else
-        [definition.name.to_sym, value]
-      end
-    end
+    constraint = if avoid_insert_conflict.present?
+                   "ON CONFLICT (#{[avoid_insert_conflict].flatten.join(', ')}) "\
+                   "DO UPDATE SET (#{column_keys}) = (#{dynamic_keys})"
+                 end
 
     sql = <<~SQL
       INSERT INTO #{self.class.table_name} ( #{column_keys} )
       VALUES (#{dynamic_keys})
+      #{constraint}
       RETURNING *
     SQL
 
+    mapping = generate_insert_mapping(sneaky_attributes_without_id)
     data = self.class.unscoped.find_by_sql([sql.squish, mapping.to_h]).first
 
     copy_internal(data, self, "@attributes")
@@ -102,6 +92,25 @@ module SneakySave
 
   def copy_internal(source, target, key)
     target.instance_variable_set(key, source.instance_variable_get(key))
+  end
+
+  def generate_insert_mapping(attributes)
+    attributes.map do |definition, value|
+      if definition.able_to_type_cast?
+        result = definition.type_cast_for_database(value)
+        if result.is_a?(Struct)
+          if result.respond_to?(:encoder)
+            [definition.name.to_sym, result.encoder.encode(value)]
+          else
+            raise RuntimeError.new('Unknown Type Casted Struct')
+          end
+        else
+          [definition.name.to_sym, result]
+        end
+      else
+        [definition.name.to_sym, value]
+      end
+    end
   end
 
   def sneaky_attributes_values

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -126,7 +126,8 @@ module SneakySave
   end
 
   def sneaky_attributes_values
-    attributes_with_values = send :attributes_with_values_for_create, attribute_names
+    attributes_for_create = send :attributes_for_create, attribute_names
+    attributes_with_values = send :attributes_with_values, attributes_for_create
     attributes_with_values.each_with_object({}) do |attribute_value, hash|
       hash[self.class.send(:arel_attribute, attribute_value[0])] = attribute_value[1]
     end

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -39,7 +39,9 @@ module SneakySave
     sneaky_attributes_without_id = sneaky_attributes_values
                                    .except { |key| key.name == "id" }
 
-    column_keys = sneaky_attributes_without_id.keys.map(&:name).join(", ")
+    column_keys = sneaky_attributes_without_id.keys
+                  .map { |key| "\"#{key}\"" } # to avoid conflicts with column names
+                  .join(", ")
     dynamic_keys = sneaky_attributes_without_id.keys
                    .map { |key| ":#{key.name}" }
                    .join(", ")

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -98,7 +98,7 @@ module SneakySave
     target.instance_variable_set(key, source.instance_variable_get(key))
   end
 
-  def generate_constraint(avoid_insert_conflict, column_keys, column_keys)
+  def generate_constraint(avoid_insert_conflict, column_keys, dynamic_keys)
     options = avoid_insert_conflict.extract_options!
     return unless avoid_insert_conflict.present?
 

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -99,11 +99,11 @@ module SneakySave
   end
 
   def generate_constraint(avoid_insert_conflict, column_keys, dynamic_keys)
-    options = avoid_insert_conflict.extract_options!
+    options = avoid_insert_conflict&.extract_options!
     return unless avoid_insert_conflict.present?
 
     on_conflict = "ON CONFLICT (#{[avoid_insert_conflict].flatten.join(', ')}) "
-    if options[:where].present?
+    if options&.dig(:where).present?
       on_conflict += "WHERE #{options[:where]} "
     end
     on_conflict += "DO UPDATE SET (#{column_keys}) = (#{dynamic_keys})"

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -63,11 +63,11 @@ module SneakySave
     mapping = generate_insert_mapping(sneaky_attributes_without_id)
     data = self.class.unscoped.find_by_sql([sql.squish, mapping.to_h]).first
 
-    copy_internal(data, self, "@attributes")
-    copy_internal(data, self, "@mutations_from_database")
-    copy_internal(data, self, "@changed_attributes")
-    copy_internal(data, self, "@new_record")
-    copy_internal(data, self, "@destroyed")
+    copy_internal(data, "@attributes")
+    copy_internal(data, "@mutations_from_database")
+    copy_internal(data, "@changed_attributes")
+    copy_internal(data, "@new_record")
+    copy_internal(data, "@destroyed")
 
     !!id
   end
@@ -94,8 +94,8 @@ module SneakySave
       update_all(changed_attributes).zero?
   end
 
-  def copy_internal(source, target, key)
-    target.instance_variable_set(key, source.instance_variable_get(key))
+  def copy_internal(source, key)
+    instance_variable_set(key, source.instance_variable_get(key))
   end
 
   def generate_constraint(avoid_insert_conflict, column_keys, dynamic_keys)

--- a/lib/sneaky-save.rb
+++ b/lib/sneaky-save.rb
@@ -131,9 +131,15 @@ module SneakySave
 
   def sneaky_attributes_values
     attributes_for_create = send :attributes_for_create, attribute_names
-    attributes_with_values = send :attributes_with_values, attributes_for_create
+    attributes_with_values = sneaky_attributes_with_values(attributes_for_create)
     attributes_with_values.each_with_object({}) do |attribute_value, hash|
       hash[self.class.arel_table[attribute_value[0]]] = attribute_value[1]
+    end
+  end
+
+  def sneaky_attributes_with_values(attribute_names)
+    attribute_names.index_with do |name|
+      _read_attribute(name)
     end
   end
 


### PR DESCRIPTION
In rails 5 id_in_database is introduced and some validation checks are build upon this new attribute (e.g.: uniqueness).